### PR TITLE
Add Windows MSVC and Visual Studio support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,13 @@ jobs:
       POWERSHELL_TELEMETRY_OPTOUT: 1
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - uses: ilammy/msvc-dev-cmd@v1
+      - name: Initialize and update submodules
+        run: |
+          git submodule init
+          git submodule update --recursive
       - name: Generate project
         run: cmake -B build
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: brew install sdl2
       - name: Build
         run: make -j$(getconf NPROCESSORS_ONLN 2>/dev/null || getconf _NPROCESSORS_ONLN)
-  build-windows:
+  build-windows-msys2:
     runs-on: windows-latest
     env:
       POWERSHELL_TELEMETRY_OPTOUT: 1
@@ -55,3 +55,14 @@ jobs:
       - name: Build
         shell: msys2 {0}
         run: make -j $NUMBER_OF_PROCESSORS
+  build-windows-msvc:
+    runs-on: windows-latest
+    env:
+      POWERSHELL_TELEMETRY_OPTOUT: 1
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Generate project
+        run: cmake -B build
+      - name: Build
+        run: cmake --build build -j (Get-WmiObject Win32_Processor).NumberOfLogicalProcessors

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 smolnes
 deobfuscated
 *.nes
+out
+build
+.vs
+CMakeSettings.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "SDL"]
+	path = SDL
+	url = git@github.com:libsdl-org/SDL.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(smolnes)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/out")
+
+option(SMOLNES_VENDORED "Use vendored dependencies" ${WIN32})
+
+if(SMOLNES_VENDORED)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/out")
+    add_subdirectory(SDL EXCLUDE_FROM_ALL)
+else()
+    find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2)
+    find_package(SDL2 REQUIRED CONFIG COMPONENTS SDL2main)
+endif()
+
+add_executable(smolnes WIN32 smolnes.c)
+add_executable(deobfuscated WIN32 deobfuscated.c)
+
+if(TARGET SDL2::SDL2main)
+    target_link_libraries(smolnes PRIVATE SDL2::SDL2main)
+    target_link_libraries(deobfuscated PRIVATE SDL2::SDL2main)
+endif()
+
+target_link_libraries(smolnes PRIVATE SDL2::SDL2)
+target_link_libraries(deobfuscated PRIVATE SDL2::SDL2)

--- a/smolnes.c
+++ b/smolnes.c
@@ -23,8 +23,8 @@ l%2)|l%2  ,M[4+l-t]=S[2+l];K[t=MB/32&2]=S[6];K[1]=S[7];K[2-t]=(K[3]=b[4]*2-1)-1;
 :*K=v&31  ;W+1:v&128?F=0,mb=5,I|=12:(F=F/2|v<<4&16,                                       !--mb)?t=a>>13,*(t==4?D=F&3,&I:t^5?t^6?&J:&c1:&c0  )=F,mb=
 5,*M=c0&  ~!(I&16),M[1]=I&16?c1:c0|1,t=I/4%4-2,*K=!                                       t?0:t^1?J&~1:J,K[1]=!t?J:t^1?J|1:b[4]-1:0;}Q+E[(K  [h-8>>e
 -12]&(b[  4]<<14-e)-1)<<e|a%(1<<e)];}Q~0;}u R(){v=m(l,h);!++l&&++h;Q+v;}u n(u v){Q P=P&125|v&128|!v*2;}int main(int w,char**av){SDL_RWread(  SDL_RW\
-FromFile  (av[1],"rb"),b,_*_,1);SDL_Init(32);void*re=SDL_CreateRenderer(SDL_CreateWindow("smolnes",0,0,_,840,4),-1,4),*tx=SDL_CreateTexture  (re,35\
-7896194,  1,256,224);             E=b+16;K[1]=(t=b[                                       4])-1;C=b[5]?E+(t<<14):cr;M[1]=(b[5]||1)*2-1;D=3-  b[6]%2;
+FromFile  (av[1],"rb"),b,_*_,1);SDL_Init(32);void*re=SDL_CreateRenderer(SDL_CreateWindow("smolnes",0,0,_,840,4),-1,4),*tx=SDL_CreateTexture  (re,2+_
+*349508,  1,256,224);             E=b+16;K[1]=(t=b[                                       4])-1;C=b[5]?E+(t<<14):cr;M[1]=(b[5]||1)*2-1;D=3-  b[6]%2;
 k(4==b[6  ]/16)mm(0,+  128,0,1),  Mb-=2,e--;l=m(~3,                                       ~0);h=m(~2,~0);w=0;kb=SDL_GetKeyboardState(0);Y:c  =L=0;k(
 N)G N;Z(  f=31&(o=R()  )){W+0:k(  o&128){R();L=1;G n;}Z(o>>5){W+0:!++l&&++h;N:g(h)g(l)g(P|32)l=m(N=~1-(N&4),~0);h=m(N+1,~0);N=0;c++;W+1:r=R  ();g(h)
 g(l)h=R(  );l=r;W+2:P  =z&~32;l=  z;h=z;W+3:l=z;h=z;!++l&&++h;}c+=4;W+16:R();k(!(P&bm[o>>6])^o/32&1)r=l+(int8_t)v>>8,h+=r,l+=v,c+=r?2:1;W-1  :x(8,24


### PR DESCRIPTION
I implemented Windows MSVC support via adding SDL as a Git submodule and adding support for building with CMake. The CMake support might work for other platforms as well.

A small change to smolnes.c was simply required to support MSVC, as MSVC doesn't support line continuation of numeric constants. So, I came up with a stylistically-appropriate refactor of that constant that doesn't require such a line continuation.

Edit:
Confirmed the CMake build support also works on Linux, with or without the `SMOLNES_VENDORED` build option.